### PR TITLE
2.0.0.alpha1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
-          - '2.6'
-          - 'jruby-9.3.1.0'
         include:
           - ruby: '3.1'
             coverage: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karafka Test gem changelog
 
-## 2.0.0 (Unreleased)
+## 2.0.0.alpha1 (2022-01-30)
 - Change the API to be more comprehensive
 - Update to work with Karafka 2.0
 - Support for Ruby 3.1

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,4 @@ source 'https://rubygems.org'
 
 plugin 'diffend'
 
-# Us this until Karafka 2.0 is released
-gem 'karafka', github: 'karafka/karafka', branch: '2.0'
-
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,14 @@
-GIT
-  remote: https://github.com/karafka/karafka.git
-  revision: bdef87b0c641bea44b586d0ffd524d7607f84b13
-  branch: 2.0
-  specs:
-    karafka (2.0.0.pre.alpha1)
-      dry-configurable (~> 0.13)
-      dry-monitor (~> 0.5)
-      dry-validation (~> 1.7)
-      rdkafka (>= 0.10)
-      thor (>= 0.20)
-      waterdrop (>= 2.1.0, < 3.0.0)
-      zeitwerk (~> 2.3)
-
 PATH
   remote: .
   specs:
-    karafka-testing (2.0.0)
+    karafka-testing (2.0.0.alpha1)
+      karafka (~> 2.0.alpha1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.1.9)
-    dry-configurable (0.13.0)
+    dry-configurable (0.14.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.6)
     dry-container (0.9.0)
@@ -33,7 +20,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
     dry-inflector (0.2.1)
-    dry-initializer (3.0.4)
+    dry-initializer (3.1.1)
     dry-logic (1.2.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
@@ -61,6 +48,14 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
     ffi (1.15.5)
+    karafka (2.0.0.alpha1)
+      dry-configurable (~> 0.13)
+      dry-monitor (~> 0.5)
+      dry-validation (~> 1.7)
+      rdkafka (>= 0.10)
+      thor (>= 0.20)
+      waterdrop (>= 2.1.0, < 3.0.0)
+      zeitwerk (~> 2.3)
     mini_portile2 (2.7.1)
     rake (13.0.6)
     rdkafka (0.11.1)
@@ -75,13 +70,12 @@ GEM
       dry-validation (~> 1.7)
       rdkafka (>= 0.10)
       zeitwerk (~> 2.3)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  karafka!
   karafka-testing!
 
 BUNDLED WITH

--- a/karafka-testing.gemspec
+++ b/karafka-testing.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
   end
 
-  # spec.add_dependency 'karafka', '~> 2.0'
+  spec.add_dependency 'karafka', '~> 2.0.alpha1'
 end

--- a/lib/karafka/testing/version.rb
+++ b/lib/karafka/testing/version.rb
@@ -4,6 +4,6 @@
 module Karafka
   module Testing
     # Current version of gem. It should match Karafka framework version
-    VERSION = '2.0.0'
+    VERSION = '2.0.0.alpha1'
   end
 end


### PR DESCRIPTION
- Change the API to be more comprehensive
- Update to work with Karafka 2.0
-  Support for Ruby 3.1
