### PR TITLE
drop support for ruby 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Change the API to be more comprehensive
 - Update to work with Karafka 2.0
 - Support for Ruby 3.1
+- Drop support for ruby 2.6
 
 ## 1.4.2 (2021-04-21)
 - Restore MIT license

--- a/karafka-testing.gemspec
+++ b/karafka-testing.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.cert_chain    = %w[certs/mensfeld.pem]
   spec.metadata      = { 'source_code_uri' => 'https://github.com/karafka/testing' }
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7'
 
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')


### PR DESCRIPTION
We are officially dropping support for ruby 2.6 because maintenance ends beginning of April 2022. More information in this post https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/. We also can't support JRuby because it is currently based on ruby 2.6.