### PR TITLE
V2.0.0.alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Test gem changelog
 
+## 2.0.0.alpha2 (2022-02-19)
+- Add `rubygems_mfa_required`
+
 ## 2.0.0.alpha1 (2022-01-30)
 - Change the API to be more comprehensive
 - Update to work with Karafka 2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    karafka-testing (2.0.0.alpha1)
-      karafka (~> 2.0.alpha1)
+    karafka-testing (2.0.0.alpha2)
+      karafka (~> 2.0.alpha2)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
       dry-configurable (~> 0.13, >= 0.13.0)
       dry-core (~> 0.5, >= 0.5)
       dry-events (~> 0.2)
-    dry-schema (1.8.0)
+    dry-schema (1.9.1)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.13, >= 0.13.0)
       dry-core (~> 0.5, >= 0.5)
@@ -41,20 +41,20 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    dry-validation (1.7.0)
+    dry-validation (1.8.0)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.7, >= 0.7.1)
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
-      dry-schema (~> 1.8, >= 1.8.0)
+      dry-schema (~> 1.9, >= 1.9.1)
     ffi (1.15.5)
-    karafka (2.0.0.alpha1)
+    karafka (2.0.0.alpha2)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)
       dry-validation (~> 1.7)
       rdkafka (>= 0.10)
       thor (>= 0.20)
-      waterdrop (>= 2.1.0, < 3.0.0)
+      waterdrop (>= 2.2.0, < 3.0.0)
       zeitwerk (~> 2.3)
     mini_portile2 (2.7.1)
     rake (13.0.6)
@@ -63,7 +63,7 @@ GEM
       mini_portile2 (~> 2.6)
       rake (> 12)
     thor (1.2.1)
-    waterdrop (2.1.0)
+    waterdrop (2.2.0)
       concurrent-ruby (>= 1.1)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)

--- a/karafka-testing.gemspec
+++ b/karafka-testing.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
   spec.cert_chain    = %w[certs/mensfeld.pem]
-  spec.metadata      = { 'source_code_uri' => 'https://github.com/karafka/testing' }
 
   spec.required_ruby_version = '>= 2.7'
 
@@ -27,5 +26,10 @@ Gem::Specification.new do |spec|
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
   end
 
-  spec.add_dependency 'karafka', '~> 2.0.alpha1'
+  spec.add_dependency 'karafka', '~> 2.0.alpha2'
+
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/karafka/karafka',
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/lib/karafka/testing/version.rb
+++ b/lib/karafka/testing/version.rb
@@ -4,6 +4,6 @@
 module Karafka
   module Testing
     # Current version of gem. It should match Karafka framework version
-    VERSION = '2.0.0.alpha1'
+    VERSION = '2.0.0.alpha2'
   end
 end


### PR DESCRIPTION
## 2.0.0.alpha2 (2022-02-19)
- Add `rubygems_mfa_required`

ref https://github.com/karafka/karafka/issues/764